### PR TITLE
fix: codecov test coverage

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          files: ./coverage/clover.xml
+          files: ./coverage/lcov.info
           flags: jest
           name: codecov-policy-password
           verbose: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -37,7 +37,7 @@ module.exports = {
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: [
-    // "json",
+    "json",
     "text",
     "lcov",
     "clover"


### PR DESCRIPTION
Fix similar to
https://github.com/sinkcup/coverage-badge/pull/22/commits/d89470e7357e64a8db538d1db54d10d3b9fe743b
Upload lcov.info instead of clover.xml.